### PR TITLE
Fixed "chipmunk" audio issue

### DIFF
--- a/flash/Recorder.as
+++ b/flash/Recorder.as
@@ -180,6 +180,7 @@ package
 		{
 			logger.log('setupMicrophone');
 			microphone = Microphone.getMicrophone();
+			microphone.codec = "Nellymoser";
 			microphone.setSilenceLevel(0);
 			microphone.rate = sampleRate;
 			microphone.gain = 50;


### PR DESCRIPTION
This was a difficult thing to find! It took forever to figure out why my recordings would randomly sound like chipmunks, but wouldn't other times. I finally noticed that this only happened when I was using recorder.js while a page using Twilio Client was open in the same browser!

Turns out: If this library is used in conjunction with another flash library (like Twilio Client) that makes use of the microphone, and that library changes the codec to Speex, then the sampling rate will be forever stuck at "16". This causes recordings to sound like "chipmunks". Resetting the codec fixes this.
